### PR TITLE
Fix eth_compileSolidity

### DIFF
--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -288,8 +288,8 @@ def eth_getCompilers():
 
 def eth_compileSolidity(code):
     combined = languages["solidity"].combined(code)
-    name = combined[len(combined) - 1][0]
-    contract = combined[len(combined) - 1][1]
+    name = combined.keys()[0]
+    contract = combined[name]
     val = {}
 
     # Support old and new versions of solc


### PR DESCRIPTION
I was using truffle and kept getting

{"error": {"message": "Server error:   File \"/usr/local/lib/python2.7/site-packages/testrpc/testrpc.py\", line 291, in eth_compileSolidity | KeyError: 0", "code": -32603}, "jsonrpc": "2.0", "id": 1}

This fixed it for me