### PR TITLE
setup rpc_configure endpoint so that static return values are configu…

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+* `py-geth` Version: x.x.x
+* `go-ethereum` Version: x.x.x
+* Python Version: x.x.x
+* OS: osx/linux/win
+
+
+### What was wrong?
+
+Please include information like:
+
+* full output of the error you received
+* what command you ran
+* the code that caused the failure
+
+#### Cute Animal Picture
+
+> put a cute animal picture here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What was wrong?
+
+
+
+### How was it fixed?
+
+
+
+#### Cute Animal Picture
+
+> put a cute animal picture here.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,14 @@ The RPC methods currently implemented are:
 * `eth_newFilter`  (temporarily removed until implemented in underlying library)
 * `eth_getFilterChanges`  (temporarily removed until implemented in underlying library)
 * `eth_uninstallFilter`  (temporarily removed until implemented in underlying library)
+* `eth_protocolVersion` ( see `rpc_configure`)
+* `eth_syncing` ( see `rpc_configure`)
+* `eth_mining` ( see `rpc_configure`)
 * `web3_sha3`
 * `web3_clientVersion`
+* `net_version` (see `rpc_configure`)
+* `net_listening` (see `rpc_configure`)
+* `net_peerCount` (see `rpc_configure`)
 
 There’s also special non-standard methods that aren’t included within the original RPC specification:
 
@@ -68,6 +74,22 @@ When calling `evm_reset`, the `testrpc` will revert the state of its internal ch
 * `evm_reset` : Run once at the beginning of your test suite.
 * `evm_snapshot` : Run at the beginning of each test, snapshotting the state of the evm.
 * `evm_revert` : Run at the end of each test, reverting back to a known clean state.
+
+
+TestRPC exposes the `rpc_configure` method which can be used to modify the
+static values returned by the following endpoints.
+
+* `eth_protocolVersion` (default `63`)
+* `eth_syncing` (default `False`)
+* `eth_mining` (default `True`)
+* `net_version` (default `1`)
+* `net_listening` (default `False`)
+* `net_peerCount` (default `0`)
+
+The `rpc_configure` takes two parameters.
+
+* `key`: string representing the rpc method on which you want to change the return value.
+* `value`: the value that should be returned by the endpoint.
 
 
 ### Releasing a new version (for eth-testrpc developers)

--- a/testrpc/server.py
+++ b/testrpc/server.py
@@ -64,6 +64,7 @@ add_method_with_lock(testrpc.eth_getFilterLogs, 'eth_getFilterLogs')
 add_method_with_lock(testrpc.eth_uninstallFilter, 'eth_uninstallFilter')
 add_method_with_lock(testrpc.eth_protocolVersion, 'eth_protocolVersion')
 add_method_with_lock(testrpc.eth_syncing, 'eth_syncing')
+add_method_with_lock(testrpc.eth_mining, 'eth_mining')
 add_method_with_lock(testrpc.web3_sha3, 'web3_sha3')
 add_method_with_lock(testrpc.web3_clientVersion, 'web3_clientVersion')
 add_method_with_lock(testrpc.net_version, 'net_version')
@@ -72,6 +73,7 @@ add_method_with_lock(testrpc.net_peerCount, 'net_peerCount')
 add_method_with_lock(testrpc.evm_reset, 'evm_reset')
 add_method_with_lock(testrpc.evm_snapshot, 'evm_snapshot')
 add_method_with_lock(testrpc.evm_revert, 'evm_revert')
+add_method_with_lock(testrpc.rpc_configure, 'rpc_configure')
 
 
 @Request.application

--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+import sys
 import pkg_resources
 import logging
 
@@ -166,12 +166,30 @@ def eth_uninstallFilter(filter_id):
     raise NotImplementedError("This has not yet been implemented")
 
 
+RPC_META = {
+    'eth_protocolVersion': 63,
+    'eth_syncing': False,
+    'eth_mining': True,
+    'net_version': 1,
+    'net_listening': False,
+    'net_peerCount': 0,
+}
+
+
+def rpc_configure(key, value):
+    RPC_META[key] = value
+
+
 def eth_protocolVersion():
-    return 63
+    return RPC_META['eth_protocolVersion']
 
 
 def eth_syncing():
-    return False
+    return RPC_META['eth_syncing']
+
+
+def eth_mining():
+    return RPC_META['eth_mining']
 
 
 def web3_sha3(value):
@@ -180,16 +198,18 @@ def web3_sha3(value):
 
 
 def web3_clientVersion():
-    return "TestRPC/" + __version__ + "/python"
+    return "TestRPC/" + __version__ + "/python/{v.major}.{v.minor}.{v.micro}".format(
+        v=sys.version_info
+    )
 
 
 def net_version():
-    return 1
+    return RPC_META['net_version']
 
 
 def net_listening():
-    return False
+    return RPC_META['net_listening']
 
 
 def net_peerCount():
-    return 0
+    return RPC_META['net_peerCount']


### PR DESCRIPTION
Sets up missing `eth_mining` endpoint as well as `rpc_configure` endpoint which can be use to configure the return values from some of the static endpoints.