### PR TITLE
Fix the two getBlockBy* endpoints

### DIFF
--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -127,11 +127,11 @@ def eth_getTransactionByHash(tx_hash):
 
 
 def eth_getBlockByHash(block_hash, full_tx=True):
-    return tester_client.get_block_hash(block_hash, full_tx)
+    return tester_client.get_block_by_hash(block_hash, full_tx)
 
 
 def eth_getBlockByNumber(block_number, full_tx=True):
-    return tester_client.get_block_number(block_number, full_tx)
+    return tester_client.get_block_by_number(block_number, full_tx)
 
 
 def eth_getTransactionReceipt(tx_hash):

--- a/tests/endpoints/test_eth_getBlockByHash.py
+++ b/tests/endpoints/test_eth_getBlockByHash.py
@@ -1,0 +1,6 @@
+def test_eth_getBlockByHash(rpc_client):
+    block_0 = rpc_client("eth_getBlockByNumber", [0, False])
+
+    block_0_by_hash = rpc_client("eth_getBlockByHash", [block_0['hash'], False])
+
+    assert block_0_by_hash == block_0

--- a/tests/endpoints/test_eth_getBlockByNumber.py
+++ b/tests/endpoints/test_eth_getBlockByNumber.py
@@ -1,0 +1,6 @@
+def test_eth_getBlockByNumber(rpc_client):
+    block_0 = rpc_client("eth_getBlockByNumber", [0, False])
+
+    assert block_0
+
+    assert block_0['number'] == "0x0"


### PR DESCRIPTION
### What was wrong?

The `getBlockByNumber` and `getBlockByHash` methods were broken.

### How was it fixed?

Fixed them to call the appropriate underlying `ethereum-tester-client` methods.

#### Cute Animal Picture

> put a cute animal picture here.

![40fb6f24b71e69e68fd37017a3ecd9e8](https://cloud.githubusercontent.com/assets/824194/16465517/613fefca-3dfc-11e6-9ebb-5f9a579fc6bc.jpg)
