### PR TITLE
add evm_mine rpc method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,20 @@ There’s also special non-standard methods that aren’t included within the or
 * `evm_snapshot` : No params. Returns the integer id of the snapshot created.
 * `evm_revert` : One optional param. Reverts to the snapshot id passed, or the latest snapshot.
 
-When calling `evm_reset`, the `testrpc` will revert the state of its internal chain back to the genesis block and it will act as if no processing of transactions has taken place. Similarly, you can use `evm_snapshot` and `evm_revert` methods to save and restore the evm state as desired. Example use cases for these methods are as follows:
+When calling `evm_reset`, the `testrpc` will revert the state of its internal
+chain back to the genesis block and it will act as if no processing of
+transactions has taken place. Similarly, you can use `evm_snapshot` and
+`evm_revert` methods to save and restore the evm state as desired. Example use
+cases for these methods are as follows:
 
 * `evm_reset` : Run once at the beginning of your test suite.
 * `evm_snapshot` : Run at the beginning of each test, snapshotting the state of the evm.
 * `evm_revert` : Run at the end of each test, reverting back to a known clean state.
 
+TestRPC also exposes the `evm_mine` method for advancing the test evm by a
+single block.
+
+* `evm_mine` : No params, no return value.
 
 TestRPC exposes the `rpc_configure` method which can be used to modify the
 static values returned by the following endpoints.

--- a/testrpc/server.py
+++ b/testrpc/server.py
@@ -73,6 +73,7 @@ add_method_with_lock(testrpc.net_peerCount, 'net_peerCount')
 add_method_with_lock(testrpc.evm_reset, 'evm_reset')
 add_method_with_lock(testrpc.evm_snapshot, 'evm_snapshot')
 add_method_with_lock(testrpc.evm_revert, 'evm_revert')
+add_method_with_lock(testrpc.evm_mine, 'evm_mine')
 add_method_with_lock(testrpc.rpc_configure, 'rpc_configure')
 
 

--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -53,6 +53,10 @@ def evm_revert(snapshot_idx=None):
         return True
 
 
+def evm_mine():
+    tester_client.mine_block()
+
+
 #
 #  Web3 Functions
 #

--- a/tests/endpoints/test_evm_mine.py
+++ b/tests/endpoints/test_evm_mine.py
@@ -1,4 +1,4 @@
-def test_eth_blockNumber(accounts, rpc_client):
+def test_evm_mine(rpc_client):
     assert rpc_client('eth_blockNumber') == "0x0"
 
     rpc_client('evm_mine')

--- a/tests/endpoints/test_evm_mine.py
+++ b/tests/endpoints/test_evm_mine.py
@@ -1,0 +1,12 @@
+def test_eth_blockNumber(accounts, rpc_client):
+    assert rpc_client('eth_blockNumber') == "0x0"
+
+    rpc_client('evm_mine')
+
+    assert rpc_client('eth_blockNumber') == "0x1"
+
+    rpc_client('evm_mine')
+    rpc_client('evm_mine')
+    rpc_client('evm_mine')
+
+    assert rpc_client('eth_blockNumber') == "0x4"


### PR DESCRIPTION
### What was wrong?

No nice way to advance the blockchain by a single block (mining)

### How was it fixed?

Added an `evm_mine` rpc function that could be used to do this.

#### Cute Animal Picture

> put a cute animal picture here.

![stock-photo-17551909](https://cloud.githubusercontent.com/assets/824194/16469156/bd7673e4-3e0c-11e6-92c3-e522b96859d3.jpg)
