### PR TITLE
update deps for homestead block configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,16 @@ static values returned by the following endpoints.
 * `net_version` (default `1`)
 * `net_listening` (default `False`)
 * `net_peerCount` (default `0`)
+* `homestead_block_number` (default `0`)
+* `dao_fork_block_number` (default `0`)
 
 The `rpc_configure` takes two parameters.
 
 * `key`: string representing the rpc method on which you want to change the return value.
 * `value`: the value that should be returned by the endpoint.
+
+The `homestead` and `dao` fork configurations determine which block number the
+fork rules should come into effect.  Both default to `0`.
 
 
 ### Releasing a new version (for eth-testrpc developers)

--- a/conftest.py
+++ b/conftest.py
@@ -77,4 +77,6 @@ def rpc_client(rpc_server):
             assert set(result.keys()) == {"id", "jsonrpc", "result"}
         return response.json()['result']
 
+    make_request.server = rpc_server
+
     return make_request

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Werkzeug>=0.11.10
 json-rpc>=1.10.3
-ethereum>1.3.6
-rlp>=0.4.4
-ethereum-tester-client>=0.7.0
+ethereum>=1.5.2
+rlp>=0.4.6
+ethereum-tester-client>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,9 @@ setup(
     install_requires=[
         'Werkzeug>=0.11.10',
         'json-rpc>=1.10.3',
-        # TODO: bump this once the next version of pyethereum is released.
-        'ethereum>1.3.6',
+        'ethereum>=1.5.2',
         'rlp>=0.4.4',
-        'ethereum-tester-client>=0.7.0',
+        'ethereum-tester-client>=0.9.0',
     ],
     entry_points={
         'console_scripts': [

--- a/testrpc/server.py
+++ b/testrpc/server.py
@@ -99,3 +99,6 @@ def application(request):
         mimetype='application/json',
     )
     return response
+
+
+application.testrpc = testrpc

--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -188,11 +188,18 @@ RPC_META = {
     'net_version': 1,
     'net_listening': False,
     'net_peerCount': 0,
+    'homestead_block_number': tester_client.evm.block.config['HOMESTEAD_FORK_BLKNUM'],
+    'dao_fork_block_number': tester_client.evm.block.config['DAO_FORK_BLKNUM'],
 }
 
 
 def rpc_configure(key, value):
     RPC_META[key] = value
+
+    if key == 'homestead_block_number':
+        tester_client.evm.block.config['HOMESTEAD_FORK_BLKNUM'] = value
+    elif key == 'dao_fork_block_number':
+        tester_client.evm.block.config['DAO_FORK_BLKNUM'] = value
 
 
 def eth_protocolVersion():

--- a/tests/endpoints/test_eth_estimateGas.py
+++ b/tests/endpoints/test_eth_estimateGas.py
@@ -2,7 +2,7 @@ CONTRACT_BIN = b'0x6060604052610114806100126000396000f360606040526000357c0100000
 
 
 def test_eth_estimate_gas(rpc_client, accounts):
-    gas_estimate = rpc_client(
+    hex_gas_estimate = rpc_client(
         method="eth_estimateGas",
         params=[{
             "from": accounts[0],
@@ -10,4 +10,5 @@ def test_eth_estimate_gas(rpc_client, accounts):
             "value": 1234,
         }],
     )
-    assert gas_estimate == '0x16c11'
+    gas_estimate = int(hex_gas_estimate, 16)
+    assert gas_estimate > 50000

--- a/tests/endpoints/test_evm_configure.py
+++ b/tests/endpoints/test_evm_configure.py
@@ -1,0 +1,18 @@
+def test_homestead_fork_block_number(rpc_client):
+    tester_client = rpc_client.server.application.testrpc.tester_client
+    assert tester_client.evm.block.config['HOMESTEAD_FORK_BLKNUM'] == 0
+
+    rpc_client('rpc_configure', ['homestead_block_number', 10])
+    rpc_client('evm_mine')
+
+    assert tester_client.evm.block.config['HOMESTEAD_FORK_BLKNUM'] == 10
+
+
+def test_dao_fork_block_number(rpc_client):
+    tester_client = rpc_client.server.application.testrpc.tester_client
+    assert tester_client.evm.block.config['DAO_FORK_BLKNUM'] == 0
+
+    rpc_client('rpc_configure', ['dao_fork_block_number', 10])
+    rpc_client('evm_mine')
+
+    assert tester_client.evm.block.config['DAO_FORK_BLKNUM'] == 10


### PR DESCRIPTION
### What was wrong?

The default configuration for `pyethereum` is to have the two fork block numbers set to the values from the main chain.  This isn't normally what people want when they are using it for a test chain.

### How was it fixed?

Pulled in the downstream version of `ethereum-tester-client` which defaults these values to `0` as well as added configuration to the `rpc_configure` endpoint for configuring this.

#### Cute Animal Picture

> put a cute animal picture here.

![dog-shaming-run-over-big-dog](https://cloud.githubusercontent.com/assets/824194/17487931/3fb5aba2-5d54-11e6-8909-8a3e42009ce6.jpg)
