### PR TITLE
Fix usage to be compliant with gevent

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,9 @@ from gevent import socket
 from gevent.pywsgi import (
     WSGIServer,
 )
+from gevent import monkey
+
+monkey.patch_socket()
 
 import requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Werkzeug>=0.11.10
 json-rpc>=1.10.3
 ethereum>=1.5.2
 rlp>=0.4.6
-ethereum-tester-client>=0.9.0
+ethereum-tester-client>=1.0.0
 click>=6.6

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,13 @@ setup(
     keywords='ethereum blockchain development testing',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=[
-        'Werkzeug>=0.11.10',
-        'json-rpc>=1.10.3',
-        'ethereum>=1.5.2',
-        'rlp>=0.4.4',
-        'ethereum-tester-client>=1.0.0',
+        "gevent>=1.1.2",
         'click>=6.6',
+        'ethereum-tester-client>=1.0.0',
+        'ethereum>=1.5.2',
+        'json-rpc>=1.10.3',
+        'rlp>=0.4.4',
+        'Werkzeug>=0.11.10',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'json-rpc>=1.10.3',
         'ethereum>=1.5.2',
         'rlp>=0.4.4',
-        'ethereum-tester-client>=0.9.0',
+        'ethereum-tester-client>=1.0.0',
         'click>=6.6',
     ],
     entry_points={

--- a/testrpc/__main__.py
+++ b/testrpc/__main__.py
@@ -1,10 +1,14 @@
 from __future__ import print_function
 
+import random
 import time
-import threading
 import codecs
 
-from wsgiref.simple_server import make_server
+import gevent
+from gevent.pywsgi import (
+    WSGIServer,
+)
+
 import click
 
 from ethereum.tester import (
@@ -42,18 +46,18 @@ def main(host, port):
 
     print("\nListening on %s:%s" % (host, port))
 
-    server = make_server(host, port, application)
+    server = WSGIServer(
+        (host, port),
+        application,
+    )
 
-    thread = threading.Thread(target=server.serve_forever)
-    thread.daemon = True
-    thread.start()
+    gevent.spawn(server.serve_forever)
 
     try:
         while True:
-            time.sleep(0.1)
+            time.sleep(random.random())
     except KeyboardInterrupt:
-        server.shutdown()
-        server.server_close()
+        server.stop()
 
 
 if __name__ == "__main__":

--- a/testrpc/__main__.py
+++ b/testrpc/__main__.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import random
-import time
 import codecs
 
 import gevent
@@ -55,7 +54,7 @@ def main(host, port):
 
     try:
         while True:
-            time.sleep(random.random())
+            gevent.sleep(random.random())
     except KeyboardInterrupt:
         server.stop()
 

--- a/testrpc/server.py
+++ b/testrpc/server.py
@@ -1,6 +1,7 @@
 import json
 import functools
-from threading import Lock
+
+from gevent.threading import Lock
 
 from werkzeug.wrappers import Request, Response
 

--- a/tests/endpoints/test_server_accepts_requests.py
+++ b/tests/endpoints/test_server_accepts_requests.py
@@ -2,7 +2,7 @@ import requests
 
 
 def test_server_listens(rpc_server):
-    host, port = rpc_server.server_address
+    host, port = rpc_server.address
 
     endpoint = "http://{host}:{port}".format(host=host, port=port)
     response = requests.post(endpoint)

--- a/tests/server/test_server_running.py
+++ b/tests/server/test_server_running.py
@@ -1,12 +1,14 @@
 import os
 import signal
 
+import gevent
+
 from click.testing import CliRunner
 
 from testrpc.testrpc import (
     web3_clientVersion,
 )
-import gevent
+
 from testrpc.__main__ import main
 
 


### PR DESCRIPTION
### What was wrong?

The library was using things that needed to be imported from `gevent` but were not.

### How was it fixed?

* Use gevent threads
* Use gevent sockets
* Use gevent wsgi servers

#### Cute Animal Picture

> put a cute animal picture here.

![4157240128_81f2a59afa_z](https://cloud.githubusercontent.com/assets/824194/17784264/187c9856-6539-11e6-859d-0dc2acb288ed.jpg)
