### PR TITLE
Pull in downstream gevent usage changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         "gevent>=1.1.2",
         'click>=6.6',
-        'ethereum-tester-client>=1.0.0',
+        'ethereum-tester-client>=1.1.0',
         'ethereum>=1.5.2',
         'json-rpc>=1.10.3',
         'rlp>=0.4.4',


### PR DESCRIPTION
### What was wrong?

There are downstream changes in `ethereum-tester-client` that remove the gevent monkeypatching behavior.

### How was it fixed?

Bumped the dependent version number.

#### Cute Animal Picture

> put a cute animal picture here.

![cat-with-bird-940x690](https://cloud.githubusercontent.com/assets/824194/18137614/47cdc9f4-6f66-11e6-8ba9-ce7f69d19fa8.jpg)
