### PR TITLE
Fix call signature of proxy call to new_filter

### DIFF
--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -165,8 +165,17 @@ def eth_newPendingTransactionFilter(*args, **kwargs):
     raise NotImplementedError("This has not yet been implemented")
 
 
+FILTER_KWARGS_MAP = {
+    'fromBlock': 'from_block',
+    'toBlock': 'to_block',
+}
+
+
 def eth_newFilter(filter_dict):
-    return tester_client.new_filter(**filter_dict)
+    kwargs = {
+        FILTER_KWARGS_MAP.get(k, k): v for k, v in filter_dict.items()
+    }
+    return tester_client.new_filter(**kwargs)
 
 
 def eth_getFilterChanges(filter_id):

--- a/tests/filters/test_installing_new_filter.py
+++ b/tests/filters/test_installing_new_filter.py
@@ -1,7 +1,25 @@
-def test_registering_new_filter(rpc_client, call_emitter_method):
+def test_registering_new_filter_with_no_args(rpc_client, call_emitter_method):
     filter_id = rpc_client(
         method='eth_newFilter',
         params=[{}]
+    )
+    changes = rpc_client(
+        method='eth_getFilterChanges',
+        params=[filter_id],
+    )
+
+    assert not changes
+
+
+def test_registering_new_filter_with_no_args(rpc_client, call_emitter_method):
+    filter_id = rpc_client(
+        method='eth_newFilter',
+        params=[{
+            'fromBlock': 1,
+            'toBlock': 10,
+            'address': '0xd3cda913deb6f67967b99d67acdfa1712c293601',
+            'topics': ['0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b'],
+        }]
     )
     changes = rpc_client(
         method='eth_getFilterChanges',


### PR DESCRIPTION
### What was wrong?

The params passed into `newFilter` were being directly fed into the `eth-tester-client` `new_filter` method.

### How was it fixed?

Added some kwargs translation to get the keywords right.

#### Cute Animal Picture

> put a cute animal picture here.

![cats-and-bird-populations_1](https://cloud.githubusercontent.com/assets/824194/18210085/25a8c0a6-70f4-11e6-8624-a2bd97d8f2c9.jpg)
