### PR TITLE
conform to RPC api by accepting hex values for transaction value, gas…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,15 @@ def accounts():
     return [normalize_address(acct) for acct in tester.accounts]
 
 
+@pytest.fixture(scope="session")
+def hex_accounts(accounts):
+    from eth_tester_client.utils import (
+        encode_address,
+        force_text,
+    )
+    return [force_text(encode_address(acct)) for acct in accounts]
+
+
 @pytest.yield_fixture()
 def rpc_server():
     from testrpc.server import application

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gevent>=1.1.2
 Werkzeug>=0.11.10
 click>=6.6
-ethereum-tester-client>=1.2.1
+ethereum-tester-client>=1.2.3
 ethereum>=1.5.2
 json-rpc>=1.10.3
 rlp>=0.4.4

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "gevent>=1.1.2",
         'Werkzeug>=0.11.10',
         'click>=6.6',
-        'ethereum-tester-client>=1.2.1',
+        'ethereum-tester-client>=1.2.3',
         'ethereum>=1.5.2',
         'json-rpc>=1.10.3',
         'rlp>=0.4.4',

--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -16,6 +16,8 @@ from eth_tester_client.utils import (
     encode_32bytes,
 )
 
+from .utils import input_transaction_formatter
+
 
 __version__ = pkg_resources.get_distribution("eth-testrpc").version
 
@@ -78,23 +80,14 @@ def eth_blockNumber():
     return encode_number(tester_client.get_block_number())
 
 
-TXN_KWARGS_MAP = {
-    'from': '_from',
-}
-
-
 def eth_sendTransaction(transaction):
-    kwargs = {
-        TXN_KWARGS_MAP.get(k, k): v for k, v in transaction.items()
-    }
-    return tester_client.send_transaction(**kwargs)
+    formatted_transaction = input_transaction_formatter(transaction)
+    return tester_client.send_transaction(**formatted_transaction)
 
 
 def eth_estimateGas(transaction, block_number="latest"):
-    kwargs = {
-        TXN_KWARGS_MAP.get(k, k): v for k, v in transaction.items()
-    }
-    return tester_client.estimate_gas(**kwargs)
+    formatted_transaction = input_transaction_formatter(transaction)
+    return tester_client.estimate_gas(**formatted_transaction)
 
 
 def eth_sendRawTransaction(raw_tx):
@@ -102,10 +95,8 @@ def eth_sendRawTransaction(raw_tx):
 
 
 def eth_call(transaction, block_number="latest"):
-    kwargs = {
-        TXN_KWARGS_MAP.get(k, k): v for k, v in transaction.items()
-    }
-    return tester_client.call(**kwargs)
+    formatted_transaction = input_transaction_formatter(transaction)
+    return tester_client.call(**formatted_transaction)
 
 
 def eth_accounts():
@@ -272,7 +263,5 @@ def personal_unlockAccount(address, passphrase, duration=None):
 
 
 def personal_signAndSendTransaction(transaction, passphrase):
-    txn_kwargs = {
-        TXN_KWARGS_MAP.get(k, k): v for k, v in transaction.items()
-    }
-    return tester_client.send_and_sign_transaction(passphrase, **txn_kwargs)
+    formatted_transaction = input_transaction_formatter(transaction)
+    return tester_client.send_and_sign_transaction(passphrase, **formatted_transaction)

--- a/testrpc/utils.py
+++ b/testrpc/utils.py
@@ -1,0 +1,29 @@
+def normalize_number(value):
+    try:
+        return int(value, 16)
+    except TypeError:
+        return int(value)
+
+
+def noop(value):
+    return value
+
+
+TXN_KWARGS_MAP = {
+    'from': '_from',
+    'gasPrice': 'gas_price',
+}
+
+
+TXN_FORMATTERS = {
+    'value': normalize_number,
+    'gas': normalize_number,
+    'gasPrice': normalize_number
+}
+
+
+def input_transaction_formatter(transaction):
+    return {
+        TXN_KWARGS_MAP.get(k, k): TXN_FORMATTERS.get(k, noop)(v)
+        for k, v in transaction.items()
+    }

--- a/tests/endpoints/test_eth_sendTransaction.py
+++ b/tests/endpoints/test_eth_sendTransaction.py
@@ -1,4 +1,5 @@
-def test_eth_sendTransaction(rpc_client, accounts):
+
+def test_eth_sendTransaction(rpc_client, accounts, hex_accounts):
     result = rpc_client(
         method="eth_sendTransaction",
         params=[{
@@ -7,7 +8,46 @@ def test_eth_sendTransaction(rpc_client, accounts):
             "value": 1234,
             "data": "0x1234",
             "gas": 100000,
+            "gasPrice": 4321,
         }],
     )
 
     assert len(result) == 66
+
+    txn = rpc_client(
+        method="eth_getTransactionByHash",
+        params=[result],
+    )
+    assert txn['from'] == hex_accounts[0]
+    assert txn['to'] == hex_accounts[1]
+    assert txn['value'] == hex(1234)
+    assert txn['input'] == '0x1234'
+    assert txn['gas'] == hex(100000)
+    assert txn['gasPrice'] == hex(4321)
+
+
+def test_eth_sendTransaction_with_hex_values(rpc_client, accounts, hex_accounts):
+    result = rpc_client(
+        method="eth_sendTransaction",
+        params=[{
+            "from": accounts[0],
+            "to": accounts[1],
+            "value": hex(1234),
+            "data": "0x1234",
+            "gas": hex(100000),
+            "gasPrice": hex(4321),
+        }],
+    )
+
+    assert len(result) == 66
+
+    txn = rpc_client(
+        method="eth_getTransactionByHash",
+        params=[result],
+    )
+    assert txn['from'] == hex_accounts[0]
+    assert txn['to'] == hex_accounts[1]
+    assert txn['value'] == hex(1234)
+    assert txn['input'] == '0x1234'
+    assert txn['gas'] == hex(100000)
+    assert txn['gasPrice'] == hex(4321)


### PR DESCRIPTION
### What was wrong?

didn't allow hex values for `gas`, `gasPrice, `value`, and `nonce`.

### How was it fixed?

Conform to RPC spec by accepting hex values for `gas`, `gasPrice, `value`, and `nonce`.

#### Cute Animal Picture

> put a cute animal picture here.

