### PR TITLE
fix eth_newFilter for hex encoded block numbers

### DIFF
--- a/testrpc/testrpc.py
+++ b/testrpc/testrpc.py
@@ -18,6 +18,7 @@ from eth_tester_client.utils import (
 
 from .utils import (
     input_transaction_formatter,
+    input_filter_params_formatter,
     normalize_block_number,
 )
 
@@ -168,11 +169,9 @@ FILTER_KWARGS_MAP = {
 }
 
 
-def eth_newFilter(filter_dict):
-    kwargs = {
-        FILTER_KWARGS_MAP.get(k, k): v for k, v in filter_dict.items()
-    }
-    return tester_client.new_filter(**kwargs)
+def eth_newFilter(filter_params):
+    formatted_filter_params = input_filter_params_formatter(filter_params)
+    return tester_client.new_filter(**formatted_filter_params)
 
 
 def eth_getFilterChanges(filter_id):

--- a/testrpc/utils.py
+++ b/testrpc/utils.py
@@ -34,3 +34,22 @@ def input_transaction_formatter(transaction):
         TXN_KWARGS_MAP.get(k, k): TXN_FORMATTERS.get(k, noop)(v)
         for k, v in transaction.items()
     }
+
+
+FILTER_KWARGS_MAP = {
+    'fromBlock': 'from_block',
+    'toBlock': 'to_block',
+}
+
+
+FILTER_FORMATTERS = {
+    'fromBlock': normalize_block_number,
+    'toBlock': normalize_block_number,
+}
+
+
+def input_filter_params_formatter(filter_params):
+    return {
+        FILTER_KWARGS_MAP.get(k, k): FILTER_FORMATTERS.get(k, noop)(v)
+        for k, v in filter_params.items()
+    }


### PR DESCRIPTION
### What was wrong?

The newly supported hex encoded block numbers borked some things.

### How was it fixed?

Normalize the block numbers for `eth_newFilter` before passing them onwards to `ethereum-tester-client`

Worth noting that this was also fixed upstream via https://github.com/pipermerriam/ethereum-tester-client/pull/25 thansk to @4gn3s.

#### Cute Animal Picture

> put a cute animal picture here.

![nwgdbni](https://cloud.githubusercontent.com/assets/824194/19091526/44f96496-8a40-11e6-8af1-32cdee1db786.jpg)
