### PR TITLE
Piper/minor utils updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
         "gevent>=1.1.2",
         'Werkzeug>=0.11.10',
         'click>=6.6',
-        'ethereum>=1.5.2,<1.6.0',  # Currently latest pyethereum tester module is broken for this use case.
+        'ethereum>=1.5.2',  # Currently latest pyethereum tester module is broken for this use case.
         'json-rpc>=1.10.3',
-        'rlp>=0.4.4',
+        'rlp>=0.4.4,<0.4.7',
     ],
     entry_points={
         'console_scripts': [

--- a/testrpc/__init__.py
+++ b/testrpc/__init__.py
@@ -1,4 +1,13 @@
 import pkg_resources
 
 
+try:
+    from sha3 import keccak_256  # NOQA
+except ImportError:
+    pass
+else:
+    import sha3
+    sha3.sha3_256 = sha3.keccak_256
+
+
 __version__ = pkg_resources.get_distribution("eth-testrpc").version

--- a/testrpc/client/utils.py
+++ b/testrpc/client/utils.py
@@ -1,6 +1,7 @@
 import sys
 import functools
 import random
+import codecs
 
 from rlp.utils import (
     int_to_big_endian,
@@ -47,38 +48,22 @@ def is_array(value):
     return isinstance(value, (list, tuple))
 
 
-if sys.version_info.major == 2:
-    def force_bytes(value):
-        if is_binary(value):
-            return str(value)
-        elif is_text(value):
-            return value.encode('latin1')
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
+def force_bytes(value):
+    if is_binary(value):
+        return bytes(value)
+    elif is_text(value):
+        return codecs.encode(value, "iso-8859-1")
+    else:
+        raise TypeError("Unsupported type: {0}".format(type(value)))
 
-    def force_text(value):
-        if is_text(value):
-            return value
-        elif is_binary(value):
-            return unicode(force_bytes(value), 'latin1')  # NOQA
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
-else:
-    def force_bytes(value):
-        if is_binary(value):
-            return bytes(value)
-        elif is_text(value):
-            return bytes(value, 'latin1')
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
 
-    def force_text(value):
-        if isinstance(value, text_types):
-            return value
-        elif isinstance(value, binary_types):
-            return str(value, 'latin1')
-        else:
-            raise TypeError("Unsupported type: {0}".format(type(value)))
+def force_text(value):
+    if is_text(value):
+        return value
+    elif is_binary(value):
+        return codecs.decode(value, "iso-8859-1")
+    else:
+        raise TypeError("Unsupported type: {0}".format(type(value)))
 
 
 def force_obj_to_bytes(obj, skip_unsupported=False):

--- a/testrpc/rpc.py
+++ b/testrpc/rpc.py
@@ -1,7 +1,10 @@
 import sys
 import logging
 
-from sha3 import sha3_256
+try:
+    from sha3 import keccak_256
+except ImportError:
+    from sha3 import sha3_256 as keccak_256
 
 from ethereum.tester import (
     languages,
@@ -37,7 +40,7 @@ class RPCMethods(object):
         self.RPC_META = {
             'eth_protocolVersion': 63,
             'eth_syncing': False,
-            'eth_mining': True,
+            'eth_mining': False,
             'net_version': 1,
             'net_listening': False,
             'net_peerCount': 0,
@@ -181,9 +184,10 @@ class RPCMethods(object):
             value = decode_hex(value)
         else:
             value = force_bytes(value)
-        return encode_32bytes(sha3_256(value).digest())
+        return encode_32bytes(keccak_256(value).digest())
 
-    def web3_clientVersion(self):
+    @classmethod
+    def web3_clientVersion(cls):
         from testrpc import __version__
         return "TestRPC/" + __version__ + "/{platform}/python{v.major}.{v.minor}.{v.micro}".format(
             v=sys.version_info,

--- a/tests/client/test_get_block_by_identifier.py
+++ b/tests/client/test_get_block_by_identifier.py
@@ -1,0 +1,29 @@
+def test_get_earliest_block(client, hex_accounts):
+    client.mine_block()
+    client.mine_block()
+
+    block = client.get_block_by_number("earliest")
+
+    assert block['number'] == b'0x0'
+
+
+def test_get_latest_block(client, hex_accounts):
+    client.mine_block() # finalizes the genesis block
+    client.mine_block() # finalizes block #1
+    client.mine_block() # finalizes block #2
+
+    block = client.get_block_by_number("latest")
+
+    assert block['number'] == b'0x2'
+    assert int(block['number'], 16) == client.get_block_number()
+
+
+def test_get_pending_block(client, hex_accounts):
+    client.mine_block() # finalizes the genesis block
+    client.mine_block() # finalizes block #1
+    client.mine_block() # finalizes block #2
+
+    block = client.get_block_by_number("pending")
+
+    assert block['number'] == b'0x3'
+    assert int(block['number'], 16) == client.get_block_number() + 1

--- a/tests/client/test_mining_blocks.py
+++ b/tests/client/test_mining_blocks.py
@@ -2,6 +2,7 @@ def test_mine_block(client):
     initial_block_number = client.get_block_number()
 
     client.mine_block()
+    client.mine_block()
 
     assert client.get_block_number() - initial_block_number == 1
 

--- a/tests/endpoints/test_evm_mine.py
+++ b/tests/endpoints/test_evm_mine.py
@@ -2,6 +2,7 @@ def test_evm_mine(rpc_client):
     assert rpc_client('eth_blockNumber') == "0x0"
 
     rpc_client('evm_mine')
+    rpc_client('evm_mine')
 
     assert rpc_client('eth_blockNumber') == "0x1"
 


### PR DESCRIPTION
### What was wrong?

The logic for getting the latest block number as well as some related logic was broken.

### How was it fixed?

Don't use `evm.block` because that block isn't finalized so it isn't the "latest" block.

#### Cute Animal Picture

> put a cute animal picture here.

![baby-monster-01](https://cloud.githubusercontent.com/assets/824194/21510687/d2da1e68-cc53-11e6-8f80-ba8310d4f2ba.gif)
