### PR TITLE
allow specifying number of blocks for evm_mine

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ cases for these methods are as follows:
 * `evm_snapshot` : Run at the beginning of each test, snapshotting the state of the evm.
 * `evm_revert` : Run at the end of each test, reverting back to a known clean state.
 
-TestRPC also exposes the `evm_mine` method for advancing the test evm by a
-single block.
+TestRPC also exposes the `evm_mine` method for advancing the test evm by some
+number of blocks.
 
-* `evm_mine` : No params, no return value.
+* `evm_mine` : Optionally supply an integer for the number of blocks to mine.  Default is 1 block. No return value.
 
 TestRPC exposes the `testing_timeTravel` method for fast-forwarding to a future timestamp.
 

--- a/testrpc/rpc.py
+++ b/testrpc/rpc.py
@@ -84,8 +84,9 @@ class RPCMethods(object):
         else:
             return True
 
-    def evm_mine(self):
-        self.client.mine_block()
+    def evm_mine(self, num_blocks=1):
+        for _ in range(num_blocks):
+            self.client.mine_block()
 
     #
     #  Timetravel

--- a/tests/endpoints/test_evm_mine.py
+++ b/tests/endpoints/test_evm_mine.py
@@ -11,3 +11,15 @@ def test_evm_mine(rpc_client):
     rpc_client('evm_mine')
 
     assert rpc_client('eth_blockNumber') == "0x4"
+
+
+def test_evm_mine_with_num_blocks(rpc_client):
+    assert rpc_client('eth_blockNumber') == "0x0"
+
+    rpc_client('evm_mine', [2])
+
+    assert rpc_client('eth_blockNumber') == "0x1"
+
+    rpc_client('evm_mine', [3])
+
+    assert rpc_client('eth_blockNumber') == "0x4"


### PR DESCRIPTION
### What was wrong?

`evm_mine` only allowed mining single blocks.  Nice to mine multiple blocks.

### How was it fixed?

Added ability to specify number of blocks to mine

#### Cute Animal Picture

> put a cute animal picture here.

![baby-bear](https://cloud.githubusercontent.com/assets/824194/21549973/434c5ae8-cdb3-11e6-81b5-0a72c7e37b6c.jpeg)
