### PR TITLE
Remove hard gevent dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ python:
   - "3.5"
 env:
   matrix:
-    - TOX_ENV=py27
-    - TOX_ENV=py34
-    - TOX_ENV=py35
+    - TOX_ENV=py27-stdlib
+    - TOX_ENV=py34-stdlib
+    - TOX_ENV=py35-stdlib
+    - TOX_ENV=py27-gevent
+    - TOX_ENV=py34-gevent
+    - TOX_ENV=py35-gevent
     - TOX_ENV=flake8
 cache:
   pip: true
@@ -14,6 +17,6 @@ install:
   - "travis_retry pip install setuptools pip --upgrade"
   - "travis_retry pip install tox"
 script:
-  - tox -e $TOX_ENV
+  - tox -e $TOX_ENV --recreate
 after_script:
   - cat .tox/$TOX_ENV/log/*.log

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Or, to upgrade:
 pip install eth-testrpc --upgrade
 ```
 
+Or, to install with gevent support
+
+```
+pip install eth-testrcp[gevent]
+```
+
 ### Run
 
 Installing through pip will make the `testrpc` command available on your machine:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ make release
 ```
 
 
+### GEvent
+
+To use the library with full gevent support set the envronment variable
+`TESTRPC_ASYNC_GEVENT`.
+
+
 ### License
 
 MIT

--- a/conftest.py
+++ b/conftest.py
@@ -152,6 +152,9 @@ def rpc_client(rpc_server):
 
             result = response.json()
 
+        if 'error' in result:
+            raise AssertionError(result['error'])
+
         return result['result']
 
     make_request.server = rpc_server

--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ from testrpc.client.utils import (  # noqa: E402
     encode_data,
     strip_0x,
     force_bytes,
+    force_text,
     encode_address,
     normalize_address,
 )
@@ -135,10 +136,10 @@ def rpc_client(rpc_server):
                 },
             )
             with contextlib.closing(client):
-                response = client.post(body=payload_data)
+                response = client.post('/', body=payload_data)
                 response_body = response.read()
 
-            result = json.loads(response_body)
+            result = json.loads(force_text(response_body))
         else:
             import requests
             response = requests.post(

--- a/conftest.py
+++ b/conftest.py
@@ -1,26 +1,55 @@
-import pytest
+# noqa: e402
+import os
+import sys
+import contextlib
 
-from gevent import monkey
-monkey.patch_socket()
-import gevent
-from gevent import socket
-from gevent.pywsgi import (
-    WSGIServer,
-)
+if 'TESTRPC_ASYNC_GEVENT' in os.environ:
+    from gevent import monkey
+    monkey.patch_socket()
 
-import json
-import requests
-import textwrap
+import pytest  # noqa: E402
 
-from ethereum.utils import sha3
+import json  # noqa: E402
+import textwrap  # noqa: E402
 
-from testrpc.client.utils import (
+from ethereum.utils import sha3  # noqa: E402
+
+from testrpc.client.utils import (  # noqa: E402
     encode_number,
-    encode_hex,
     encode_data,
     strip_0x,
     force_bytes,
+    encode_address,
+    normalize_address,
 )
+from testrpc.async import (  # noqa: E402
+    make_server,
+    spawn,
+    Timeout,
+    sleep,
+    socket,
+)
+
+
+if sys.version_info.major == 2:
+    ConnectionRefusedError = socket.timeout
+
+
+def wait_for_http_connection(port, timeout=5):
+    with Timeout(timeout) as _timeout:
+        while True:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(1)
+            try:
+                s.connect(('127.0.0.1', port))
+            except (socket.timeout, ConnectionRefusedError):
+                sleep(0.1)
+                _timeout.check()
+                continue
+            else:
+                break
+        else:
+            raise ValueError("Unable to establish HTTP connection")
 
 
 def get_open_port():
@@ -31,20 +60,16 @@ def get_open_port():
     s.close()
     return port
 
+
 @pytest.fixture(scope="session")
 def accounts():
     from ethereum import tester
-    from testrpc.client.utils import normalize_address
     return [normalize_address(acct) for acct in tester.accounts]
     #  return [b"0x" + encode_hex(acct) for acct in tester.accounts]
 
 
 @pytest.fixture(scope="session")
 def hex_accounts(accounts):
-    from testrpc.client.utils import (
-        encode_address,
-        force_text,
-    )
     return [encode_address(acct) for acct in accounts]
 
 
@@ -56,15 +81,21 @@ def rpc_server():
 
     port = get_open_port()
 
-    server = WSGIServer(
-        ('127.0.0.1', port),
+    server = make_server(
+        '127.0.0.1',
+        port,
         application,
     )
-    gevent.spawn(server.serve_forever)
+    thread = spawn(server.serve_forever)
+    wait_for_http_connection(port)
 
     yield server
 
-    server.stop()
+    try:
+        server.stop()
+    except AttributeError:
+        server.shutdown()
+    thread.join()
 
 
 nonce = 0
@@ -74,10 +105,14 @@ nonce = 0
 def rpc_client(rpc_server):
     from testrpc.client.utils import force_obj_to_text
 
-    host, port = rpc_server.address
+    try:
+        host, port = rpc_server.address
+    except AttributeError:
+        host, port = rpc_server.server_address
+
     endpoint = "http://{host}:{port}".format(host=host, port=port)
 
-    def make_request(method, params=None, raise_on_error=True):
+    def make_request(method, params=None):
         global nonce
         nonce += 1  # NOQA
         payload = {
@@ -87,18 +122,36 @@ def rpc_client(rpc_server):
             "params": params or [],
         }
         payload_data = json.dumps(force_obj_to_text(payload, True))
-        response = requests.post(endpoint, data=payload_data)
 
-        if raise_on_error:
-            assert response.status_code == 200
+        if 'TESTRPC_ASYNC_GEVENT' in os.environ:
+            from geventhttpclient import HTTPClient
+            client = HTTPClient(
+                host=host,
+                port=port,
+                connection_timeout=10,
+                network_timeout=10,
+                headers={
+                    'Content-Type': 'application/json',
+                },
+            )
+            with contextlib.closing(client):
+                response = client.post(body=payload_data)
+                response_body = response.read()
+
+            result = json.loads(response_body)
+        else:
+            import requests
+            response = requests.post(
+                endpoint,
+                data=payload_data,
+                headers={
+                    'Content-Type': 'application/json',
+                },
+            )
 
             result = response.json()
 
-            if 'error' in result:
-                raise AssertionError(result['error'])
-
-            assert set(result.keys()) == {"id", "jsonrpc", "result"}
-        return response.json()['result']
+        return result['result']
 
     make_request.server = rpc_server
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 pytest==2.9.2
 requests==2.10.0
-gevent==1.1.2
 rlp==0.4.6

--- a/requirements-gevent.txt
+++ b/requirements-gevent.txt
@@ -1,0 +1,3 @@
+-r requirements-dev.txt
+gevent>=1.1.1,<1.2
+geventhttpclient>=1.3.1

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,17 @@ setup(
     keywords='ethereum blockchain development testing',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=[
-        "gevent>=1.1.2",
         'Werkzeug>=0.11.10',
         'click>=6.6',
         'ethereum>=1.5.2',
         'json-rpc>=1.10.3',
         'rlp>=0.4.4,<0.4.7',
     ],
+    extras_require={
+        'gevent': [
+            "gevent>=1.1.1,<1.2.0",
+        ],
+    },
     entry_points={
         'console_scripts': [
             'testrpc-py=testrpc.cli:runserver',

--- a/testrpc/async/__init__.py
+++ b/testrpc/async/__init__.py
@@ -1,0 +1,27 @@
+import os
+
+
+def is_using_gevent():
+    return 'TESTRPC_ASYNC_GEVENT' in os.environ
+
+
+if is_using_gevent():
+    from .gevent_async import (  # noqa
+        Timeout,
+        spawn,
+        sleep,
+        subprocess,
+        socket,
+        threading,
+        make_server,
+    )
+else:
+    from .stdlib_async import (  # noqa
+        Timeout,
+        spawn,
+        sleep,
+        subprocess,
+        socket,
+        threading,
+        make_server,
+    )

--- a/testrpc/async/gevent_async.py
+++ b/testrpc/async/gevent_async.py
@@ -2,13 +2,15 @@ import gevent
 from gevent.pywsgi import (  # noqa: F401
     WSGIServer,
 )
+from gevent import (  # noqa; F401
+    subprocess,
+    threading,
+    socket,
+)
 
 
 sleep = gevent.sleep
-socket = gevent.socket
 spawn = gevent.spawn
-subprocess = gevent.subprocess
-threading = gevent.threading
 
 
 class Timeout(gevent.Timeout):

--- a/testrpc/async/gevent_async.py
+++ b/testrpc/async/gevent_async.py
@@ -1,0 +1,21 @@
+import gevent
+from gevent.pywsgi import (  # noqa: F401
+    WSGIServer,
+)
+
+
+sleep = gevent.sleep
+socket = gevent.socket
+spawn = gevent.spawn
+subprocess = gevent.subprocess
+threading = gevent.threading
+
+
+class Timeout(gevent.Timeout):
+    def check(self):
+        pass
+
+
+def make_server(host, port, application, *args, **kwargs):
+    server = WSGIServer((host, port), application, *args, **kwargs)
+    return server

--- a/testrpc/async/stdlib_async.py
+++ b/testrpc/async/stdlib_async.py
@@ -1,0 +1,103 @@
+"""
+A minimal implementation of the various gevent APIs used within this codebase.
+"""
+import time
+import threading
+import socket  # noqa: F401
+import subprocess  # noqa: F401
+from wsgiref.simple_server import make_server  # noqa: F401
+
+
+sleep = time.sleep
+
+
+class Timeout(Exception):
+    """
+    A limited subset of the `gevent.Timeout` context manager.
+    """
+    seconds = None
+    exception = None
+    begun_at = None
+    is_running = None
+
+    def __init__(self, seconds=None, exception=None, *args, **kwargs):
+        self.seconds = seconds
+        self.exception = exception
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def __str__(self):
+        if self.seconds is None:
+            return ''
+        return "{0} seconds".format(self.seconds)
+
+    @property
+    def expire_at(self):
+        if self.seconds is None:
+            raise ValueError("Timeouts with `seconds == None` do not have an expiration time")
+        elif self.begun_at is None:
+            raise ValueError("Timeout has not been started")
+        return self.begun_at + self.seconds
+
+    def start(self):
+        if self.is_running is not None:
+            raise ValueError("Timeout has already been started")
+        self.begun_at = time.time()
+        self.is_running = True
+
+    def check(self):
+        if self.is_running is None:
+            raise ValueError("Timeout has not been started")
+        elif self.is_running is False:
+            raise ValueError("Timeout has already been cancelled")
+        elif self.seconds is None:
+            return
+        elif time.time() > self.expire_at:
+            self.is_running = False
+            if isinstance(self.exception, type):
+                raise self.exception(str(self))
+            elif isinstance(self.exception, Exception):
+                raise self.exception
+            else:
+                raise self
+
+    def cancel(self):
+        self.is_running = False
+
+
+class empty(object):
+    pass
+
+
+class ThreadWithReturn(threading.Thread):
+    def __init__(self, target=None, args=None, kwargs=None):
+        super(ThreadWithReturn, self).__init__(target=target, args=args, kwargs=kwargs)
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self):
+        self._return = self.target(*self.args, **self.kwargs)
+
+    def get(self, timeout=None):
+        self.join(timeout)
+        try:
+            return self._return
+        except AttributeError:
+            raise RuntimeError("Something went wrong.  No `_return` property was set")
+
+
+def spawn(target, *args, **kwargs):
+    thread = ThreadWithReturn(
+        target=target,
+        args=args,
+        kwargs=kwargs,
+    )
+    thread.daemon = True
+    thread.start()
+    return thread

--- a/testrpc/cli.py
+++ b/testrpc/cli.py
@@ -52,7 +52,10 @@ def runserver(host, port):
         while True:
             sleep(random.random())
     except KeyboardInterrupt:
-        server.stop()
+        try:
+            server.stop()
+        except AttributeError:
+            server.shutdown()
 
 
 if __name__ == "__main__":

--- a/testrpc/cli.py
+++ b/testrpc/cli.py
@@ -3,11 +3,6 @@ from __future__ import print_function
 import random
 import codecs
 
-import gevent
-from gevent.pywsgi import (
-    WSGIServer,
-)
-
 import click
 
 from ethereum.tester import (
@@ -15,6 +10,11 @@ from ethereum.tester import (
 )
 
 from .server import get_application
+from .async import (
+    make_server,
+    spawn,
+    sleep,
+)
 
 
 @click.command()
@@ -40,16 +40,17 @@ def runserver(host, port):
 
     print("\nListening on %s:%s" % (host, port))
 
-    server = WSGIServer(
-        (host, port),
+    server = make_server(
+        host,
+        port,
         application,
     )
 
-    gevent.spawn(server.serve_forever)
+    spawn(server.serve_forever)
 
     try:
         while True:
-            gevent.sleep(random.random())
+            sleep(random.random())
     except KeyboardInterrupt:
         server.stop()
 

--- a/testrpc/client/client.py
+++ b/testrpc/client/client.py
@@ -8,7 +8,7 @@ import time
 import itertools
 import functools
 
-from gevent.threading import Lock
+from testrpc.async import threading
 
 import rlp
 
@@ -72,7 +72,7 @@ class EthTesterClient(object):
     dao_fork_support = True
 
     def __init__(self):
-        self._evm_lock = Lock()
+        self._evm_lock = threading.Lock()
 
         self.snapshots = []
 

--- a/testrpc/server.py
+++ b/testrpc/server.py
@@ -1,13 +1,12 @@
 import json
 import functools
 
-from gevent.threading import Lock
-
 from werkzeug.wrappers import Request, Response
 
 from jsonrpc import JSONRPCResponseManager, dispatcher
 
 from .rpc import RPCMethods
+from .async import threading
 from .client.utils import (
     force_obj_to_text,
 )
@@ -25,7 +24,7 @@ def get_application():
     # multithreaded HTTP server, the EVM itself is not thread-safe, so we must take
     # care when interacting with it.
     rpc_methods = RPCMethods()
-    evm_lock = Lock()
+    evm_lock = threading.Lock()
 
     def with_lock(rpc_fn):
         @functools.wraps(rpc_fn)

--- a/tests/concurrency/test_ethtester_async.py
+++ b/tests/concurrency/test_ethtester_async.py
@@ -15,18 +15,17 @@ def test_async_requests():
     to_addr = utils.encode_hex(tester.accounts[1])
 
     def spam_block_number():
-        for i in range(5):
+        for i in range(2):
             try:
                 client.send_transaction(
                     to=to_addr,
                     value=1,
                 )
-                client.mine_block()
             except Exception as e:
                 errors.append(e)
                 pytest.fail(''.join(e.args))
 
-    for i in range(5):
+    for i in range(3):
         thread = async.spawn(spam_block_number)
         threads.append(thread)
 

--- a/tests/concurrency/test_ethtester_async.py
+++ b/tests/concurrency/test_ethtester_async.py
@@ -1,10 +1,10 @@
 import pytest
-import gevent
 
 from ethereum import tester
 from ethereum import utils
 
 from testrpc.client import EthTesterClient
+from testrpc import async
 
 
 def test_async_requests():
@@ -26,8 +26,10 @@ def test_async_requests():
                 pytest.fail(''.join(e.args))
 
     for i in range(5):
-        thread = gevent.spawn(spam_block_number)
+        thread = async.spawn(spam_block_number)
+        threads.append(thread)
 
+    assert threads
     [thread.join() for thread in threads]
 
     assert not errors

--- a/tests/concurrency/test_ethtester_async.py
+++ b/tests/concurrency/test_ethtester_async.py
@@ -21,6 +21,7 @@ def test_async_requests():
                     to=to_addr,
                     value=1,
                 )
+                client.mine_block()
             except Exception as e:
                 errors.append(e)
                 pytest.fail(''.join(e.args))

--- a/tests/endpoints/test_server_accepts_requests.py
+++ b/tests/endpoints/test_server_accepts_requests.py
@@ -2,7 +2,10 @@ import requests
 
 
 def test_server_listens(rpc_server):
-    host, port = rpc_server.address
+    try:
+        host, port = rpc_server.address
+    except AttributeError:
+        host, port = rpc_server.server_address
 
     endpoint = "http://{host}:{port}".format(host=host, port=port)
     response = requests.post(endpoint)

--- a/tests/server/test_server_running.py
+++ b/tests/server/test_server_running.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 
 from testrpc.cli import runserver
 from testrpc.rpc import RPCMethods
+from testrpc import async
 from testrpc.async import socket
 
 

--- a/tests/server/test_server_running.py
+++ b/tests/server/test_server_running.py
@@ -1,12 +1,11 @@
 import os
 import signal
 
-import gevent
-
 from click.testing import CliRunner
 
 from testrpc.cli import runserver
 from testrpc.rpc import RPCMethods
+from testrpc.async import socket
 
 
 def get_open_port():
@@ -27,10 +26,10 @@ def test_main_module_for_cli_server_running():
     pid = os.getpid()
 
     def kill_it():
-        gevent.sleep(2)
+        async.sleep(2)
         os.kill(pid, signal.SIGINT)
 
-    gevent.spawn(kill_it)
+    async.spawn(kill_it)
 
     result = runner.invoke(runserver, ['--port', str(port)])
     assert result.exit_code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist=
-    py27,
-    py34,
-    py35,
+    py{27,34,35}-{gevent,stdlib},
     flake8
 
 [flake8]
@@ -13,6 +11,13 @@ exclude= tests/*
 commands=py.test {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
+    gevent: -r{toxinidir}/requirements-gevent.txt
+setenv =
+    gevent: TESTRPC_ASYNC_GEVENT=True
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
### What was wrong

Gevent doesn't play very nicely with others.  It's great if it's used across the whole stack but otherwise it causes problems.  Having it as a hard dependency no longer makes sense.

### How as it fixed?

Added `testrpc.async` module which conditionally imports either stdlib async tools or gevent based ones.

#### Cute animal picture

![6a010535647bf3970b0191023e12b7970c-500wi](https://cloud.githubusercontent.com/assets/824194/21785616/9207300e-d67d-11e6-9c08-6c55b3575080.jpg)
