### PR TITLE
update ethereum and pyrlp dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 pytest==2.9.2
 requests==2.10.0
-rlp==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-gevent>=1.1.2
-Werkzeug>=0.11.10
-click>=6.6
-ethereum>=1.5.2
-json-rpc>=1.10.3
-rlp>=0.4.4

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
     install_requires=[
         'Werkzeug>=0.11.10',
         'click>=6.6',
-        'ethereum>=1.5.2',
+        'ethereum>=1.6.1',
         'json-rpc>=1.10.3',
-        'rlp>=0.4.4,<0.4.7',
+        'rlp>=0.4.7',
     ],
     extras_require={
         'gevent': [


### PR DESCRIPTION
### What was wrong?

Upstream dependencies were pinned at older versions of `ethereum` and `rlp`.  This has become problematic.

### How was it fixed?

Unpinned to old versions.  Also removed redundant `requirements.txt` file.

#### Cute Animal Picture

> put a cute animal picture here.

![cute_pig](https://cloud.githubusercontent.com/assets/824194/24207532/bef89e76-0ee6-11e7-91fe-63009bbcc7e6.jpeg)
