### PR TITLE
Change earliest identifier to return block 1 instead of block 0

### DIFF
--- a/testrpc/client/client.py
+++ b/testrpc/client/client.py
@@ -164,7 +164,7 @@ class EthTesterClient(object):
             else:
                 return self.evm.blocks[-1]
         elif block_number == "earliest":
-            return self.evm.blocks[0]
+            return self.evm.blocks[1]
         elif block_number == "pending":
             return self.evm.block
         else:

--- a/tests/client/test_get_block_by_identifier.py
+++ b/tests/client/test_get_block_by_identifier.py
@@ -4,7 +4,7 @@ def test_get_earliest_block(client, hex_accounts):
 
     block = client.get_block_by_number("earliest")
 
-    assert block['number'] == b'0x0'
+    assert block['number'] == b'0x1'
 
 
 def test_get_latest_block(client, hex_accounts):


### PR DESCRIPTION
### What was wrong?
This PR is in response to issue #72 which calls for the earliest block identifier to return block 1 as opposed to block 0.


### How was it fixed?
I fixed it by changing the ```get_block_by_identifier``` test to expect block ```0x1``` as opposed to ```0x0```.
Then I change the client to return block 1 from the evm instead of block 0.


#### Cute Animal Picture
![image](https://cloud.githubusercontent.com/assets/17552858/25411583/d31042ba-29da-11e7-9bf3-077f08f16ce2.png)

