### PR TITLE
create and test set_balance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The RPC methods currently implemented are:
 * `eth_compileSolidity`
 * `eth_getCode` (only supports block number “latest”)
 * `eth_getBalance`
+* `eth_setBalance`
 * `eth_getTransactionCount`
 * `eth_getTransactionByHash`
 * `eth_getTransactionReceipt`

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'Werkzeug>=0.11.10',
         'click>=6.6',
-        'ethereum>=1.6.1',
+        'ethereum>=1.6.1,<2.0.0',
         'json-rpc>=1.10.3',
         'rlp>=0.4.7',
     ],

--- a/testrpc/client/client.py
+++ b/testrpc/client/client.py
@@ -315,6 +315,10 @@ class EthTesterClient(object):
         _block = self._get_block_by_number(block)
         return _block.get_balance(strip_0x(address))
 
+    def set_balance(self, address, value, block="latest"):
+        _block = self._get_block_by_number(block)
+        return _block.set_balance(strip_0x(address), value)
+
     def call(self, *args, **kwargs):
         if len(args) >= 7 and args[6] != "latest":
             raise ValueError("Using call on any block other than latest is unsupported")

--- a/testrpc/rpc.py
+++ b/testrpc/rpc.py
@@ -160,6 +160,9 @@ class RPCMethods(object):
     def eth_getBalance(self, address, block_number="latest"):
         return self.client.get_balance(address, normalize_block_number(block_number))
 
+    def eth_setBalance(self, address, value, block_number="latest"):
+        return self.client.set_balance(address, value, normalize_block_number(block_number))
+
     def eth_getTransactionCount(self, address, block_number="latest"):
         return encode_number(self.client.get_transaction_count(
             address,

--- a/testrpc/server.py
+++ b/testrpc/server.py
@@ -53,6 +53,7 @@ def get_application():
     add_method_with_lock(rpc_methods.eth_compileSolidity, 'eth_compileSolidity')
     add_method_with_lock(rpc_methods.eth_getCode, 'eth_getCode')
     add_method_with_lock(rpc_methods.eth_getBalance, 'eth_getBalance')
+    add_method_with_lock(rpc_methods.eth_setBalance, 'eth_setBalance')
     add_method_with_lock(rpc_methods.eth_getTransactionCount, 'eth_getTransactionCount')
     add_method_with_lock(rpc_methods.eth_getTransactionByHash, 'eth_getTransactionByHash')
     add_method_with_lock(rpc_methods.eth_getTransactionReceipt, 'eth_getTransactionReceipt')

--- a/tests/endpoints/test_eth_setBalance.py
+++ b/tests/endpoints/test_eth_setBalance.py
@@ -1,0 +1,9 @@
+def test_eth_setBalance(rpc_client, accounts):
+    before_balance = rpc_client("eth_getBalance", [accounts[0]])
+
+    rpc_client("eth_setBalance", [accounts[0], 1234])
+
+    after_balance = rpc_client("eth_getBalance", [accounts[0]])
+    
+    assert before_balance == 1000000000000000000000000
+    assert after_balance  == 1234


### PR DESCRIPTION
### What was wrong?
`Pip install` installed ethereum 2.0.4 which is incompatible with the existing `eth-testrpc`.  I also wanted to be able to set the exact balance of an account (for increased precision when testing).

### How was it fixed?
`Pip install` now will install a compatible version of ethereum and I created a method called `eth_setBalance` which allows a user to set the balance of an account.


#### Cute Animal Picture
![finger-monkey](https://user-images.githubusercontent.com/17552858/27811051-e58df35e-601e-11e7-8221-a955007e21ac.jpg)

@pipermerriam Thanks for all the work you do (been using a lot of your tools recently)
