### PR TITLE
Pin to pyethereum<2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'Werkzeug>=0.11.10',
         'click>=6.6',
-        'ethereum>=1.6.1',
+        'ethereum>=1.6.1,<2.0.0',
         'json-rpc>=1.10.3',
         'rlp>=0.4.7',
     ],


### PR DESCRIPTION
### What was wrong?

Library currently doesn't work with latest pyethereum

### How was it fixed?

Pin to `ethereum<2.0.0`

#### Cute Animal Picture

![adorable-shy-baby-monkey-in-paris-zoo-001](https://user-images.githubusercontent.com/824194/27924267-e9c6166a-623d-11e7-8b0f-fcccbcd9995e.jpg)
