### PR TITLE
pad logs_bloom to 256 bytes

### DIFF
--- a/testrpc/client/serializers.py
+++ b/testrpc/client/serializers.py
@@ -79,7 +79,7 @@ def serialize_block(block, full_transactions):
         transactions = [encode_32bytes(txn.hash) for txn in block.transaction_list]
 
     unpadded_logs_bloom = int_to_big_endian(block.bloom)
-    logs_bloom = zpad(unpadded_logs_bloom, (256 - len(unpadded_logs_bloom)))
+    logs_bloom = zpad(unpadded_logs_bloom, 256)
 
     return {
         "number": encode_number(block.number),

--- a/tests/client/test_get_block_by_number.py
+++ b/tests/client/test_get_block_by_number.py
@@ -6,6 +6,7 @@ def test_get_block_with_no_transactions(client, hex_accounts):
     assert block['number'] == b"0x1"
     assert block['miner'] == hex_accounts[0]
     assert len(block['transactions']) == 0
+    assert len(block['logsBloom']) == 256
 
 
 def test_get_block_with_transactions(client, hex_accounts):


### PR DESCRIPTION
### What was wrong?

logs_bloom was not the correct length

### How was it fixed?

pad to 256 bytes (`zpad` takes the desired length, not the number of zeros to add)

#### Cute Animal Picture

![cute pic](https://img.buzzfeed.com/buzzfeed-static/static/2014-06/26/19/campaign_images/webdr10/this-baby-porcupine-makes-the-cutest-noise-when-i-2-31113-1403823990-0_dblbig.jpg)
