### PR TITLE
Return logsBloom as hex-encoded

### DIFF
--- a/testrpc/client/serializers.py
+++ b/testrpc/client/serializers.py
@@ -3,8 +3,6 @@ from rlp.utils import (
     int_to_big_endian,
 )
 
-from ethereum.utils import zpad
-
 from .utils import (
     encode_32bytes,
     encode_number,
@@ -78,8 +76,7 @@ def serialize_block(block, full_transactions):
     else:
         transactions = [encode_32bytes(txn.hash) for txn in block.transaction_list]
 
-    unpadded_logs_bloom = int_to_big_endian(block.bloom)
-    logs_bloom = zpad(unpadded_logs_bloom, 256)
+    logs_bloom_bytes = int_to_big_endian(block.bloom)
 
     return {
         "number": encode_number(block.number),
@@ -87,8 +84,7 @@ def serialize_block(block, full_transactions):
         "parentHash": encode_32bytes(block.prevhash),
         "nonce": encode_32bytes(block.nonce),
         "sha3Uncles": encode_32bytes(block.uncles_hash),
-        # TODO logsBloom / padding
-        "logsBloom": logs_bloom,
+        "logsBloom": encode_data(logs_bloom_bytes, 256),
         "transactionsRoot": encode_32bytes(block.tx_list_root),
         "stateRoot": encode_32bytes(block.state_root),
         "miner": encode_address(block.coinbase),

--- a/tests/client/test_get_block_by_number.py
+++ b/tests/client/test_get_block_by_number.py
@@ -6,7 +6,7 @@ def test_get_block_with_no_transactions(client, hex_accounts):
     assert block['number'] == b"0x1"
     assert block['miner'] == hex_accounts[0]
     assert len(block['transactions']) == 0
-    assert len(block['logsBloom']) == 256
+    assert block['logsBloom'] == b"0x" + b"00" * 256
 
 
 def test_get_block_with_transactions(client, hex_accounts):

--- a/tests/endpoints/test_eth_getBlockByNumber.py
+++ b/tests/endpoints/test_eth_getBlockByNumber.py
@@ -4,3 +4,4 @@ def test_eth_getBlockByNumber(rpc_client):
     assert block_0
 
     assert block_0['number'] == "0x0"
+    assert block_0['logsBloom'] == "0x" + "00" * 256


### PR DESCRIPTION
### What was wrong?

`logsBloom` was being returned as raw bytes. All other fields are hex-encoded.

### How was it fixed?

hex-encode `logsBloom`

#### Cute Animal Picture

![cute pic](https://www.demilked.com/magazine/wp-content/uploads/2014/04/marutaro-cute-hedgehog-funny-paper-faces-25.jpg)
