### PR TITLE
encode nonce as 8 bytes

### DIFF
--- a/testrpc/client/serializers.py
+++ b/testrpc/client/serializers.py
@@ -85,7 +85,7 @@ def serialize_block(block, full_transactions):
         "number": encode_number(block.number),
         "hash": encode_32bytes(block.hash),
         "parentHash": encode_32bytes(block.prevhash),
-        "nonce": encode_32bytes(block.nonce),
+        "nonce": encode_data(block.nonce, 8),
         "sha3Uncles": encode_32bytes(block.uncles_hash),
         # TODO logsBloom / padding
         "logsBloom": logs_bloom,

--- a/tests/endpoints/test_eth_getBlockByNumber.py
+++ b/tests/endpoints/test_eth_getBlockByNumber.py
@@ -3,4 +3,5 @@ def test_eth_getBlockByNumber(rpc_client):
 
     assert block_0
 
+    assert len(block_0['nonce']) == 2 + 2 * 8  # nonce is 8 bytes
     assert block_0['number'] == "0x0"


### PR DESCRIPTION
### What was wrong?

According to the yellow paper, the block nonce should be 8 bytes:

![image](https://user-images.githubusercontent.com/205327/32029056-c7816f9e-b9a6-11e7-8cb7-af8accd32770.png)

### How was it fixed?

Encoded nonce as 8 bytes instead of 32.

#### Cute Animal Picture

![hedgehog](https://static.boredpanda.com/blog/wp-content/uploads/2017/02/cute-hedgehog-photos-11-58930c93cbc61__700.jpg)