### PR TITLE
bump pyethereum version to 2.1.3 to be compatible with vyper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'Werkzeug>=0.11.10',
         'click>=6.6',
-        'ethereum>=1.6.1,<2.0.0',
+        'ethereum==2.1.3',
         'json-rpc>=1.10.3',
         'rlp>=0.4.7',
     ],


### PR DESCRIPTION
### What was wrong?
Vyper now requires pyethereum "==2.1.3". Eth-testrpc requires ">=1.6.1,<2.0.0"
[Vyper support instructions](https://github.com/ethereum/populus/blob/master/docs/viper_support.rst) fail due to this incompatibility.


### How was it fixed?
Bumped pyethereum version in setup.py.
All tests pass.


#### Cute Animal Picture

![cute animal](https://s-media-cache-ak0.pinimg.com/originals/44/5e/34/445e34a7d4afad3f7c12eea4145790e6.jpg)