### PR TITLE
Fix evm state not reverted after a transaction failure in call().

### DIFF
--- a/testrpc/client/client.py
+++ b/testrpc/client/client.py
@@ -321,8 +321,10 @@ class EthTesterClient(object):
         if kwargs.get('block', 'latest') != "latest":
             raise ValueError("Using call on any block other than latest is unsupported")
         snapshot_idx = self.snapshot_evm()
-        output = self._send_transaction(*args, **kwargs)
-        self.revert_evm(snapshot_idx)
+        try:
+            output = self._send_transaction(*args, **kwargs)
+        finally:
+            self.revert_evm(snapshot_idx)
 
         return encode_data(output)
 


### PR DESCRIPTION
### What was wrong?

EVM state was not reverted after a transaction failure in `call()`. This has led to user not able to perform any other transaction after the failed `call()`. In comparison, it should follow the same `try...finally` pattern as the one in `estimate_gas()`.

### How was it fixed?

Wrap `_send_transaction()` with `try...finally` block to ensure `revert_evm()` is called if any exception occurs.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/1946265/38451548-bee5135c-39e6-11e8-9ed9-32f247382803.png)

