### PR TITLE
pin version of rlp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'click>=6.6',
         'ethereum>=1.6.1,<2.0.0',
         'json-rpc>=1.10.3',
-        'rlp>=0.4.7',
+        'rlp>=0.4.7,<=0.6.0',
     ],
     extras_require={
         'gevent': [


### PR DESCRIPTION
### What was wrong?

see ethereum/web3.py#799

### How was it fixed?

Temporarily pin `rlp` version to  `0.6.0` until the codebase is made compatible with `rlp. 1.0.1`  

